### PR TITLE
chore/shayan/ignore environment file in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /node_modules
+.env
+.env.*
+*.env


### PR DESCRIPTION
All of FE repositories are public, and during testing, .env files are prone to be pushed or committed accidentally and leak some credentials to the public

Add/update .gitignore files with the following

.env
.env.*
*.env
this will cover most of the use cases to not accidentally add credentials to the commit repository